### PR TITLE
docs: add references to github pages docs

### DIFF
--- a/packages/wethegit-react-hooks/README.md
+++ b/packages/wethegit-react-hooks/README.md
@@ -1,0 +1,5 @@
+# @wethegit/react-hooks
+
+A collection of helpers for use in React projects.
+
+[Documentation](https://wethegit.github.io/react-hooks/)

--- a/packages/wethegit-react-hooks/package.json
+++ b/packages/wethegit-react-hooks/package.json
@@ -27,7 +27,7 @@
     "local storage",
     "accessibility"
   ],
-  "homepage": "https://github.com/wethegit/react-hooks",
+  "homepage": "https://wethegit.github.io/react-hooks/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wethegit/react-hooks.git"


### PR DESCRIPTION
[docs] patch: Add references to GitHub pages docs

## Description
- Update package.json "homepage" field to point to GitHub pages docs
- Add readme to the package itself. Reason for this is to ensure there's a link to docs, for someone viewing the package on the NPM site.