### PR TITLE
fix: support commonjs

### DIFF
--- a/.changeset/brown-dots-think.md
+++ b/.changeset/brown-dots-think.md
@@ -1,0 +1,5 @@
+---
+"@wethegit/react-hooks": patch
+---
+
+fix: support commonjs

--- a/packages/wethegit-react-hooks/package.json
+++ b/packages/wethegit-react-hooks/package.json
@@ -13,7 +13,8 @@
       "import": {
         "types": "./dist/main.d.ts",
         "default": "./dist/react-hooks.js"
-      }
+      },
+      "require": "./dist/react-hooks.js"
     }
   },
   "scripts": {

--- a/packages/wethegit-react-hooks/package.json
+++ b/packages/wethegit-react-hooks/package.json
@@ -14,7 +14,7 @@
         "types": "./dist/main.d.ts",
         "default": "./dist/react-hooks.js"
       },
-      "require": "./dist/react-hooks.js"
+      "require": "./dist/react-hooks.cjs"
     }
   },
   "scripts": {

--- a/packages/wethegit-react-hooks/vite.config.ts
+++ b/packages/wethegit-react-hooks/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       // eslint-disable-next-line no-undef
       entry: resolve(__dirname, "src/lib/index.ts"),
       name: "ReactHooks",
-      formats: ["es"],
+      formats: ["es", "cjs"],
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled


### PR DESCRIPTION
## Description

After fixing the types export, the commonjs implementation got messed up as it requires a specific export key or that it be the default path in the `exports` property.