### PR TITLE
release: v3.0.1

### DIFF
--- a/packages/wethegit-react-hooks/package.json
+++ b/packages/wethegit-react-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/react-hooks",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A collection of helpers for use in React projects.",
   "files": [
     "dist"


### PR DESCRIPTION
## Description

Manually bumps patch version of the `wethegit-react-hooks` package. Will manually publish it once merged to `main`
